### PR TITLE
fix(manifests): updating release # and adding nodePort to service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 rootfs/bin/minio
+vendor/

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: deis-minio-rc
+  name: deis-minio
   labels:
     heritage: deis
-    release: 0.0.1-20151028155016
+    release: 0.0.1-20151123130904
 spec:
   replicas: 1
   selector:

--- a/manifests/deis-minio-service.yaml
+++ b/manifests/deis-minio-service.yaml
@@ -7,8 +7,10 @@ metadata:
     heritage: deis
     release: 0.0.0
 spec:
+  type: NodePort
   ports:
     - port: 9000
+      nodePort: 32760
       targetPort: 9000
       name: s3
       protocol: TCP


### PR DESCRIPTION
`nodePort` allows the minio service to be accessible from the host machine for k8s clusters run inside vagrant

cc/ @smothiki 
