### PR TITLE
fix(Makefile): enumerate both the admin and user secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ DEIS_REGISTRY ?= ${DEV_REGISTRY}
 
 RC := manifests/deis-${SHORT_NAME}-rc.yaml
 SVC := manifests/deis-${SHORT_NAME}-service.yaml
-SEC := manifests/deis-${SHORT_NAME}-secretAdmin.yaml
-IMAGE := ${DEIS_REGISTRY}/${IMAGE_PREFIX}/${SHORT_NAME}:${VERSION}
+ADMIN_SEC := manifests/deis-${SHORT_NAME}-secretAdmin.yaml
+USER_SEC := manifests/deis-${SHORT_NAME}-secretUser.yaml
+IMAGE := ${DEIS_REGISTRY}${SHORT_NAME}:${VERSION}
 
 all: build docker-build docker-push
 
@@ -44,12 +45,8 @@ kube-rc: kube-service
 	kubectl create -f ${RC}
 
 kube-secrets:
-	- kubectl create -f ${SEC}
-
-secrets:
-	perl -pi -e "s|access-key-id: .+|access-key-id: ${key}|g" ${SEC}
-	perl -pi -e "s|access-secret-key: .+|access-secret-key: ${secret}|g" ${SEC}
-	echo ${key} ${secret}
+	kubectl create -f ${ADMIN_SEC}
+	kubectl create -f ${USER_SEC}
 
 kube-service: kube-secrets
 	- kubectl create -f ${SVC}

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -12,7 +12,6 @@ spec:
   template:
     metadata:
       labels:
-        # Important: these labels need to match the selector above
         app: deis-minio
     spec:
       containers:

--- a/manifests/deis-minio-service.yaml
+++ b/manifests/deis-minio-service.yaml
@@ -13,5 +13,4 @@ spec:
       name: s3
       protocol: TCP
   selector:
-    # Match the selector in the RC
     app: deis-minio


### PR DESCRIPTION
addresses part of https://github.com/deis/minio/issues/1

other changes:
- remove trailing slash on `DEIS_REGISTRY` usage
- remove `secrets` build target. I don't believe it's necessary. @smothiki care to comment?
