### PR TITLE
fix(deploy.sh): build the binary before build/push container

### DIFF
--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -7,6 +7,6 @@ cd "$(dirname "$0")" || exit 1
 
 export IMAGE_PREFIX=deisci VERSION=v2-alpha
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-DEIS_REGISTRY='' make -C .. bjild docker-build docker-push
+DEIS_REGISTRY='' make -C .. build docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
 DEIS_REGISTRY=quay.io/ make -C .. build docker-build docker-push

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -7,6 +7,6 @@ cd "$(dirname "$0")" || exit 1
 
 export IMAGE_PREFIX=deisci VERSION=v2-alpha
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-DEIS_REGISTRY='' make -C .. docker-build docker-push
+DEIS_REGISTRY='' make -C .. bjild docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io
-DEIS_REGISTRY=quay.io/ make -C .. docker-build docker-push
+DEIS_REGISTRY=quay.io/ make -C .. build docker-build docker-push


### PR DESCRIPTION
forgetting to `make build` was an oversight on my part. this should fix the `exec: "boot": executable file not found in $PATH` issues when running `quay.io/deisci/minio:v2-alpha` containers
