### PR TITLE
feat(.travis.yml,deploy.sh): push docker image from all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ script:
   - make test
 deploy:
   provider: script
-  script: _scripts/deploy.sh
   on:
-    branch: master
+    all_branches: true
+  script: _scripts/deploy.sh

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -5,7 +5,15 @@
 
 cd "$(dirname "$0")" || exit 1
 
-export IMAGE_PREFIX=deisci VERSION=v2-alpha
+BRANCH=$(git symbolic-ref --short -q HEAD)
+
+VER=v2-alpha
+if ![ $BRANCH == "master" ]; then
+  # deploy to "test-$BRANCH" tag if on a branch
+  VER="test-$BRANCH"
+fi
+
+export IMAGE_PREFIX=deisci VERSION=$VER
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
 DEIS_REGISTRY='' make -C .. build docker-build docker-push
 docker login -e="$QUAY_EMAIL" -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io

--- a/_scripts/deploy.sh
+++ b/_scripts/deploy.sh
@@ -5,12 +5,14 @@
 
 cd "$(dirname "$0")" || exit 1
 
-BRANCH=$(git symbolic-ref --short -q HEAD)
 
 VER=v2-alpha
-if ![ $BRANCH == "master" ]; then
-  # deploy to "test-$BRANCH" tag if on a branch
-  VER="test-$BRANCH"
+# note that we must check TRAVIS_PULL_REQUEST first because, for pull request builds, TRAVIS_BRANCH will contain the name of the branch that the PR is _targeting_ (not the name of the branch it is trying to merge).
+# see https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables for an explanation of TRAVIS_PULL_REQUEST and TRAVIS_BRANCH
+if [[ $TRAVIS_PULL_REQUEST != "false" ]; then
+  VER="pr-$TRAVIS_PULL_REQUEST"
+elif  [[ $TRAVIS_BRANCH != "master" ]]; then
+  VER="branch-$TRAVIS_BRANCH"
 fi
 
 export IMAGE_PREFIX=deisci VERSION=$VER


### PR DESCRIPTION
images pushed from branches will be pushed with the tag `test-$BRANCH`

Thoughts @mboersma? It looks like this could work with Travis and it'd sure be nice to have all PRs built and deployed. Maybe a good idea to push to a different org entirely (`deispulls` for example)?

If this or some future variant of it are ok I'd like to make the change across the other repos that push Docker images as well.
