### PR TITLE
fix(rootfs/Dockerfile,mc/Dockerfile): set DOCKERIMAGE environment variables

### DIFF
--- a/mc/Dockerfile
+++ b/mc/Dockerfile
@@ -7,4 +7,7 @@ ADD mc /bin/mc
 ADD ./integration.sh /bin/integration.sh
 RUN chmod +x /bin/integration.sh
 
+# this is so the minio client (https://github.com/minio/mc) works properly
+ENV DOCKERIMAGE=1
+
 CMD mc

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,6 +3,8 @@ FROM ubuntu-debootstrap:14.04
 ENV MINIOHOME /home/minio
 ENV MINIOUSER minio
 RUN useradd -m -d $MINIOHOME $MINIOUSER
+# this is so the minio client (https://github.com/minio/mc) works properly
+ENV DOCKERIMAGE=1
 
 RUN apt-get update -y && apt-get install -y -q \
 		ca-certificates \


### PR DESCRIPTION
These variables allow `mc` and the server to run even when compiled without cgo. See https://github.com/minio/mc/pull/1539 for more detail.
