### PR TITLE
fix(glide.lock,glide.yaml): revert to old version of pkg/aboutme

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -182,7 +182,7 @@ imports:
 - name: github.com/deckarep/golang-set
   version: ef32fa3046d9f249d399f98ebaf9be944430fd1d
 - name: github.com/deis/pkg
-  version: ee60d947fecd410bd9ea30ffb53f9ea3e6dc038e
+  version: f63d9718b86f17c9320f838fb3eb6039cadb9691
   subpackages:
   - aboutme
 - name: github.com/denverdino/aliyungo

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
 - package: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - package: github.com/deis/pkg/aboutme
-  version: ">=0.2.1"
+  version: f63d9718b86f17c9320f838fb3eb6039cadb9691
 - package: github.com/google/protobuf
   version: b640f216a56ae25aab9a1fc6f21aa1a56c304494
 ignore:


### PR DESCRIPTION
this commit reverts part of
https://github.com/deis/minio/pull/36/files#diff-395f41b2a27b70ce44399c9
1c82158c2R14.

On master, the following error is observed in production when minio
pods launch:

``` console
{"log":"Fatal error  pods \"deis-minio-2i9kv\" not
found\n","stream":"stdout","time":"2015-12-29T23:58:53.330822679Z"}`
```

cc/ @sgoings @slack 
