### PR TITLE
fix(Dockerfile): run the server without alpine support

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -4,8 +4,6 @@ ENV MINIOHOME /home/minio
 ENV MINIOUSER minio
 ENV DEIS_RELEASE=2.0.0-dev
 RUN useradd -m -d $MINIOHOME $MINIOUSER
-# this is so the minio client (https://github.com/minio/mc) works properly
-ENV DOCKERIMAGE=1
 
 RUN apt-get update -y && apt-get install -y -q \
 		ca-certificates \


### PR DESCRIPTION
Doing so was making minio look at /.minio for config on startup, which
was failing because it’s not allowed to write to / inside the container.

Fixes #43 

cc/ @krancour @slack 
