### PR TITLE
fix(deis-minio): store minio data on a persistent volume

### DIFF
--- a/manifests/deis-minio-pv.yaml
+++ b/manifests/deis-minio-pv.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: minio-data
+  name: deis-minio-data
   labels:
     type: local
 spec:

--- a/manifests/deis-minio-pv.yaml
+++ b/manifests/deis-minio-pv.yaml
@@ -1,0 +1,13 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: minio-data
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 8Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /mnt/minio/data

--- a/manifests/deis-minio-pvc.yaml
+++ b/manifests/deis-minio-pvc.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: minio-data
+  name: deis-minio-data
   labels:
     type: local
 spec:

--- a/manifests/deis-minio-pvc.yaml
+++ b/manifests/deis-minio-pvc.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Reclaim
   resources:
     requests:
       storage: 8Gi

--- a/manifests/deis-minio-pvc.yaml
+++ b/manifests/deis-minio-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: minio-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Reclaim
+  resources:
+    requests:
+      storage: 8Gi

--- a/manifests/deis-minio-pvc.yaml
+++ b/manifests/deis-minio-pvc.yaml
@@ -2,6 +2,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: minio-data
+  labels:
+    type: local
 spec:
   accessModes:
     - ReadWriteOnce

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -49,7 +49,7 @@ spec:
             secretName: minio-user
         - name: minio-data
           persistentVolumeClaim:
-            claimName: minio-data
+            claimName: deis-minio-data
 
         # - name: minio-ssl
         #   secret:

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -26,8 +26,8 @@ spec:
             # not running with ssl yet
             # - "--cert=/var/run/secrets/deis/minio/ssl/access-cert"
             # - "--key=/var/run/secrets/deis/minio/ssl/access-pem"
-            - "server"
-            - "/mnt/minio/data"
+            - server
+            - /mnt/minio/data
           volumeMounts:
             - name: minio-admin
               mountPath: /var/run/secrets/deis/minio/admin

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -35,6 +35,8 @@ spec:
             - name: minio-user
               mountPath: /var/run/secrets/deis/minio/user
               readOnly: true
+            - name: minio-data
+              mountPath: /mnt/minio/data
             # - name: minio-ssl
             #   mountPath: /var/run/secrets/deis/minio/ssl
             #   readOnly: true
@@ -46,7 +48,9 @@ spec:
           secret:
             secretName: minio-user
         - name: minio-data
-          
+          PersistentVolumeClaim:
+            claimName: minio-data
+
         # - name: minio-ssl
         #   secret:
         #     secretName: minio-ssl

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -27,7 +27,7 @@ spec:
             # - "--cert=/var/run/secrets/deis/minio/ssl/access-cert"
             # - "--key=/var/run/secrets/deis/minio/ssl/access-pem"
             - "server"
-            - "/home/minio/"
+            - "/mnt/minio/data"
           volumeMounts:
             - name: minio-admin
               mountPath: /var/run/secrets/deis/minio/admin
@@ -45,6 +45,8 @@ spec:
         - name: minio-user
           secret:
             secretName: minio-user
+        - name: minio-data
+          
         # - name: minio-ssl
         #   secret:
         #     secretName: minio-ssl

--- a/manifests/deis-minio-rc.yaml
+++ b/manifests/deis-minio-rc.yaml
@@ -48,7 +48,7 @@ spec:
           secret:
             secretName: minio-user
         - name: minio-data
-          PersistentVolumeClaim:
+          persistentVolumeClaim:
             claimName: minio-data
 
         # - name: minio-ssl

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update -y && apt-get install -y -q curl
 RUN curl -f -SL https://dl.minio.io:9000/updates/2015/Sept/linux-amd64/mc -o /usr/bin/mc
 RUN chmod 755 /usr/bin/mc
 COPY . /
+RUN mkdir -p /mnt/minio/data && chmod 777 /mnt/minio/data
 USER minio
 RUN mkdir /home/minio/.minio
 ENTRYPOINT ["boot"]


### PR DESCRIPTION
This PR only enables persistence on the host's disk.

Volumes Reference: http://kubernetes.io/v1.1/docs/user-guide/volumes.html#persistentvolumeclaim
Persistence reference: https://github.com/kubernetes/kubernetes/blob/release-1.1/docs/user-guide/persistent-volumes.md

Related: https://github.com/deis/charts/pull/72
Ref: https://github.com/deis/deis/issues/4809
