### PR TITLE
fix(mc/Dockerfile): make the mc image use alpine:3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,6 @@ kube-mc-integration:
 build-server:
 	docker run -e GO15VENDOREXPERIMENT=1 -e GOROOT=/usr/local/go --rm -v "${CURDIR}/server":/pwd -w /pwd golang:1.5.2 ./install.sh
 
-# targets for mc
-
 mc-build:
 	make -C mc build
 

--- a/mc/Dockerfile
+++ b/mc/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu-debootstrap:14.04
+FROM alpine:3.3
 
-RUN apt-get update -y && apt-get install -y -q ca-certificates
+RUN apk add -U ca-certificates && rm -rf /var/cache/apk/*
 
 ADD mc /bin/mc
 

--- a/mc/Makefile
+++ b/mc/Makefile
@@ -7,7 +7,7 @@ MC_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/mc:${VERSION}
 MC_INTEGRATION_IMAGE := ${DEIS_REGISTRY}${IMAGE_PREFIX}/mc:${VERSION}
 
 build:
-	docker run -e GO15VENDOREXPERIMENT=1 -e GOROOT=/usr/local/go --rm -v ${CURDIR}:/pwd -w /pwd golang:1.5.2 ./install.sh
+	docker run -e CGO_ENABLED=0 -e GO15VENDOREXPERIMENT=1 -e GOROOT=/usr/local/go --rm -v ${CURDIR}:/pwd -w /pwd golang:1.5.2 ./install.sh
 
 docker-build:
 	docker build -t ${MC_IMAGE} ${CURDIR}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,11 +1,13 @@
-FROM alpine:3.3
+FROM ubuntu-debootstrap:14.04
 
 ENV MINIOHOME /home/minio
 ENV MINIOUSER minio
 ENV DEIS_RELEASE=2.0.0-dev
-RUN adduser -D -h $MINIOHOME $MINIOUSER
-RUN apk add -U ca-certificates yasm curl && rm -rf /var/cache/apk/*
+RUN useradd -m -d $MINIOHOME $MINIOUSER
+RUN apt-get update -y && apt-get install -y -q ca-certificates curl
+RUN curl -f -SL https://dl.minio.io:9000/updates/2015/Sept/linux-amd64/mc -o /usr/bin/mc
+RUN chmod 755 /usr/bin/mc
 COPY . /
 USER minio
 RUN mkdir /home/minio/.minio
-ENTRYPOINT ["boot"]
+CMD "boot"

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,16 +1,10 @@
-FROM ubuntu-debootstrap:14.04
+FROM alpine:3.3
 
 ENV MINIOHOME /home/minio
 ENV MINIOUSER minio
 ENV DEIS_RELEASE=2.0.0-dev
-RUN useradd -m -d $MINIOHOME $MINIOUSER
-
-RUN apt-get update -y && apt-get install -y -q \
-		ca-certificates \
-		yasm
-RUN apt-get update -y && apt-get install -y -q curl
-RUN curl -f -SL https://dl.minio.io:9000/updates/2015/Sept/linux-amd64/mc -o /usr/bin/mc
-RUN chmod 755 /usr/bin/mc
+RUN adduser -D -h $MINIOHOME $MINIOUSER
+RUN apk add -U ca-certificates yasm curl && rm -rf /var/cache/apk/*
 COPY . /
 USER minio
 RUN mkdir /home/minio/.minio


### PR DESCRIPTION
Fixes part of #8.

The remaining work to be done is to _compile_ the minio server (with `make build-server`) with `CGO_ENABLED=0`. Currently that process fails.
