### PR TITLE
ref(Makefile,manifests/*): use envtpl to render dev manifests

### DIFF
--- a/manifests/deis-mc-integration-pod.tpl.yaml
+++ b/manifests/deis-mc-integration-pod.tpl.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: deis-mc
+  name: deis-mc-integration
+  namespace: {{.POD_NAMESPACE}}
   labels:
     heritage: deis
     version: 2.0.0-beta
@@ -11,16 +12,22 @@ spec:
   containers:
     - name: mc
       imagePullPolicy: Always
-      image: quay.io/deisci/mc:v2-beta
+      image: {{.POD_IMAGE}}
       command:
-        - mc
+        - /bin/integration.sh
       args:
         - "mode memory limit 512MB"
       volumeMounts:
         - name: minio-user
           mountPath: /var/run/secrets/deis/minio/user
           readOnly: true
+        - name: minio-ssl
+          mountPath: /var/run/secrets/deis/minio/ssl
+          readOnly: true
   volumes:
     - name: minio-user
       secret:
         secretName: minio-user
+    - name: minio-ssl
+      secret:
+        secretName: minio-ssl

--- a/manifests/deis-mc-pod.tpl.yaml
+++ b/manifests/deis-mc-pod.tpl.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: deis-mc-integration
+  name: deis-mc
+  namespace: {{.POD_NAMESPACE}}
   labels:
     heritage: deis
     version: 2.0.0-beta
@@ -11,22 +12,16 @@ spec:
   containers:
     - name: mc
       imagePullPolicy: Always
-      image: quay.io/deisci/mc-integration:v2-beta
+      image: {{.POD_IMAGE}}
       command:
-        - /bin/integration.sh
+        - mc
       args:
         - "mode memory limit 512MB"
       volumeMounts:
         - name: minio-user
           mountPath: /var/run/secrets/deis/minio/user
           readOnly: true
-        - name: minio-ssl
-          mountPath: /var/run/secrets/deis/minio/ssl
-          readOnly: true
   volumes:
     - name: minio-user
       secret:
         secretName: minio-user
-    - name: minio-ssl
-      secret:
-        secretName: minio-ssl

--- a/manifests/deis-minio-rc.tpl.yaml
+++ b/manifests/deis-minio-rc.tpl.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: deis-minio
+  namespace: {{.RC_NAMESPACE}}
   labels:
     heritage: deis
     release: 2.0.0-beta
@@ -16,7 +17,7 @@ spec:
     spec:
       containers:
         - name: deis-minio
-          image: quay.io/arschles/minio:devel
+          image: {{.RC_IMAGE}}
           imagePullPolicy: Always
           env:
             - name: HEALTH_SERVER_PORT

--- a/manifests/deis-minio-secretAdmin.yaml
+++ b/manifests/deis-minio-secretAdmin.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: minio-admin
+  namespace: {{.SECRET_NAMESPACE}}
   heritage: deis
 type: Opaque
 data:

--- a/manifests/deis-minio-secretUser.tpl.yaml
+++ b/manifests/deis-minio-secretUser.tpl.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: minio-user
+  namespace: {{.SECRET_NAMESPACE}}
   heritage: deis
 type: Opaque
 data:

--- a/manifests/deis-minio-secretssl.tpl.yaml
+++ b/manifests/deis-minio-secretssl.tpl.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: minio-ssl
+  namespace: {{.SECRET_NAMESPACE}}
   heritage: deis
 type: Opaque
 data:

--- a/manifests/deis-minio-service.tpl.yaml
+++ b/manifests/deis-minio-service.tpl.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   # Give this a useful name.
   name: deis-minio
+  namespace: {{.SVC_NAMESPACE}}
   labels:
     heritage: deis
     release: 0.0.0


### PR DESCRIPTION
This patch changes k8s manifests into Go templates and uses [envtpl](https://github.com/arschles/envtpl) to render them from the makefile. It then sends the rendered result directly into `kubectl create`, which can accept manifests from STDIN.

If maintainers like this style, we can apply it to other repos.
