### PR TITLE
update(minio): update to minio server to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ kube-mc-integration:
 
 # build the minio server
 build-server:
-	docker run -e GO15VENDOREXPERIMENT=1 -e GOROOT=/usr/local/go --rm -v "${CURDIR}/server":/pwd -w /pwd golang:1.5.2 ./install.sh
+	docker run -e GO15VENDOREXPERIMENT=1 -e GOROOT=/usr/local/go --rm -v "${CURDIR}/server":/pwd -w /pwd golang:1.6 ./install.sh
 
 mc-build:
 	make -C mc build

--- a/server/install.sh
+++ b/server/install.sh
@@ -12,7 +12,8 @@
 apt-get update && apt-get install -yq yasm
 mkdir -p $GOPATH/src/github.com/minio
 cd $GOPATH/src/github.com/minio
-git clone -b deis --single-branch https://github.com/deis/minio-src.git minio
+git clone -b master --single-branch https://github.com/minio/minio.git minio
 cd minio
+git reset --hard 356b889
 make install
 cp $GOPATH/bin/minio /pwd/minio


### PR DESCRIPTION
Use the minio master branch to build the mino server. This is required as they have few fixes which are useful for registry to use minio as the backend.
