### PR TITLE
chore(Makefile): update to go-dev:0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export GO15VENDOREXPERIMENT=1
 
 # dockerized development environment variables
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.5.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.1
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/glide.lock
+++ b/glide.lock
@@ -1,204 +1,24 @@
-hash: 4afce67bc453566ffffe0ce7b8b8b3659cf1000db5f1d90d19902dd672f330f5
-updated: 2016-02-05T23:18:33.568574547Z
+hash: 5bbac2d1624df033a6051ebdb8ddfe4089fc5176cce7cfb70be556b21031d775
+updated: 2016-03-15T19:24:20.96594444Z
 imports:
-- name: bitbucket.org/bertimus9/systemstat
-  version: 1468fd0db20598383c9393cccaa547de6ad99e5e
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c
-- name: code.google.com/p/go-uuid
-  version: ""
-  subpackages:
-  - uuid
-- name: code.google.com/p/go.crypto
-  version: ""
-  repo: https://code.google.com/p/go.crypto
-- name: code.google.com/p/go.net
-  version: ""
-  repo: https://code.google.com/p/go.net
-- name: code.google.com/p/go.text
-  version: ""
-  repo: https://code.google.com/p/go.text
-- name: code.google.com/p/google-api-go-client
-  version: ""
-  repo: https://code.google.com/p/google-api-go-client
-- name: code.google.com/p/goprotobuf
-  version: ""
-  repo: https://code.google.com/p/goprotobuf
-- name: code.google.com/p/gosqlite
-  version: ""
-  repo: https://code.google.com/p/gosqlite
-- name: code.google.com/p/log4go
-  version: ""
-  repo: https://code.google.com/p/log4go
-- name: github.com/abbot/go-http-auth
-  version: c0ef4539dfab4d21c8ef20ba2924f9fc6f186d35
-- name: github.com/agtorre/gocolorize
-  version: f42b554bf7f006936130c9bb4f971afd2d87f671
-  repo: https://github.com/agtorre/gocolorize
-- name: github.com/akrennmair/gopcap
-  version: 00e11033259acb75598ba416495bb708d864a010
-- name: github.com/appc/cni
-  version: 2a58bd9379ca33579f0cf631945b717aa4fa373d
-  subpackages:
-  - libcni
-  - pkg/invoke
-  - pkg/types
-- name: github.com/appc/spec
-  version: c928a0c907c96034dfc0a69098b2179db5ae7e37
-  subpackages:
-  - schema
-- name: github.com/armon/circbuf
-  version: bbbad097214e2918d8543d5201d12bfd7bca254d
-  repo: https://github.com/armon/circbuf
-- name: github.com/armon/go-metrics
-  version: eb0af217e5e9747e41dd5303755356b62d28e3ec
-- name: github.com/armon/go-radix
-  version: 4239b77079c7b5d1243b7b4736304ce8ddb6f0f2
-  repo: https://github.com/armon/go-radix
-- name: github.com/armon/gomdb
-  version: 151f2e08ef45cb0e57d694b2562f351955dff572
-  repo: https://github.com/armon/gomdb
-- name: github.com/aws/aws-sdk-go
-  version: c4ae871ffc03691a7b039fa751a1e7afee56e920
-  subpackages:
-  - aws
-  - internal/endpoints
-  - internal/protocol/ec2query
-  - internal/protocol/query
-  - internal/protocol/rest
-  - internal/protocol/xml/xmlutil
-  - internal/signer/v4
-  - service/autoscaling
-  - service/ec2
-  - service/elb
-- name: github.com/Azure/azure-sdk-for-go
-  version: 97d9593768bbbbd316f9c055dfc5f780933cd7fc
-  subpackages:
-  - storage
-- name: github.com/Azure/go-ansiterm
-  version: 70b2c90b260171e829f1ebd7c17f600c11858dbe
-- name: github.com/Azure/go-pkcs12
-  version: 40102598fec19246e36fb595018ce387dbd7b3cc
-  repo: https://github.com/Azure/go-pkcs12
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:
   - quantile
-- name: github.com/bgentry/speakeasy
-  version: 36e9cfdd690967f4f690c6edcc9ffacd006014a0
-- name: github.com/bitly/go-simplejson
-  version: aabad6e819789e569bd6aabf444c935aa9ba1e44
-- name: github.com/bmizerany/pat
-  version: b8a35001b773c267eb260a691f4e5499a3531600
-  repo: https://github.com/bmizerany/pat
-- name: github.com/boltdb/bolt
-  version: 0f053fabc06119583d61937a0a06ef0ba0f1b301
-- name: github.com/bradfitz/gomemcache
-  version: fb1f79c6b65acda83063cbc69f6bba1522558bfc
-  repo: https://github.com/bradfitz/gomemcache
-- name: github.com/bradfitz/http2
-  version: f8202bc903bda493ebba4aa54922d78430c2c42f
-- name: github.com/bugsnag/bugsnag-go
-  version: b1d153021fcd90ca3f080db36bec96dc690fb274
-- name: github.com/bugsnag/osext
-  version: 0dd3f918b21bec95ace9dc86c7e70266cfc5c702
-- name: github.com/bugsnag/panicwrap
-  version: e2c28503fcd0675329da73bf48b33404db873782
-- name: github.com/BurntSushi/toml
-  version: f706d00e3de6abe700c994cdd545a1a4915af060
-- name: github.com/cbroglie/mapstructure
-  version: 25325b46b67d1c3eb7d58bad37d34d89a31cf9ec
-- name: github.com/cheggaaa/pb
-  version: da1f27ad1d9509b16f65f52fd9d8138b0f2dc7b2
-- name: github.com/ClusterHQ/flocker-go
-  version: 3f33ece70f6571f0ec45bfae2f243ab11fab6c52
-- name: github.com/codegangsta/cli
-  version: a65b733b303f0055f8d324d805f393cd3e7a7904
-- name: github.com/codegangsta/negroni
-  version: 8d75e11374a1928608c906fe745b538483e7aeb2
-- name: github.com/coreos/etcd
-  version: e4561dd8cfb1163fb51afceca9c78aa89398e731
-  subpackages:
-  - client
-- name: github.com/coreos/fleet
-  version: 1b9073ca18676d5e32bca6901e6dd765d66b7c2b
-  subpackages:
-  - client
-  - etcd
-  - job
-  - log
-  - machine
-  - pkg
-  - registry
-  - schema
-  - unit
-- name: github.com/coreos/gexpect
-  version: 5173270e159f5aa8fbc999dc7e3dcb50f4098a69
-- name: github.com/coreos/go-etcd
-  version: 4cceaf7283b76f27c4a732b20730dcdb61053bf5
-  subpackages:
-  - etcd
-- name: github.com/coreos/go-iptables
-  version: 83dfad0f13fd7310fb3c1cb8563248d8d604b95b
-  subpackages:
-  - iptables
-- name: github.com/coreos/go-oidc
-  version: ee7cb1fb480df22f7d8c4c90199e438e454ca3b6
-  subpackages:
-  - http
-  - jose
-  - key
-  - oauth2
-  - oidc
-- name: github.com/coreos/go-semver
-  version: 6fe83ccda8fb9b7549c9ab4ba47f47858bc950aa
-  subpackages:
-  - semver
-- name: github.com/coreos/go-systemd
-  version: 97e243d21a8e232e9d8af38ba2366dfcfceebeba
-  subpackages:
-  - daemon
-  - dbus
-  - unit
-- name: github.com/coreos/pkg
-  version: fa94270d4bac0d8ae5dc6b71894e251aada93f74
-  subpackages:
-  - capnslog
-  - health
-  - httputil
-  - timeutil
-- name: github.com/cpuguy83/go-md2man
-  version: 71acacd42f85e5e82f70a55327789582a5200a90
-  subpackages:
-  - md2man
-- name: github.com/d2g/dhcp4
-  version: f0e4d29ff0231dce36e250b2ed9ff08412584bca
-- name: github.com/d2g/dhcp4client
-  version: bed07e1bc5b85f69c6f0fd73393aa35ec68ed892
+- name: github.com/blang/semver
+  version: 31b736133b98f26d5e078ec9eb591666edfd091f
 - name: github.com/davecgh/go-spew
   version: 3e6e67c4dcea3ac2f25fd4731abc0e1deaf36216
   subpackages:
   - spew
-- name: github.com/daviddengcn/go-colortext
-  version: b5c0891944c2f150ccc9d02aecf51b76c14c2948
-- name: github.com/deckarep/golang-set
-  version: ef32fa3046d9f249d399f98ebaf9be944430fd1d
 - name: github.com/deis/pkg
-  version: f63d9718b86f17c9320f838fb3eb6039cadb9691
+  version: 20cd6d3875d29b186b47d7466dcc1672db01619c
   subpackages:
-  - /aboutme
-  - /utils
-- name: github.com/denverdino/aliyungo
-  version: 6ffb587da9da6d029d0ce517b85fecc82172d502
-  subpackages:
-  - oss
-  - util
-  - common
-- name: github.com/dgrijalva/jwt-go
-  version: 5ca80149b9d3f8b863af0e2bb6742e608603bd99
-- name: github.com/docker/distribution
-  version: dd58349b355f346a020a08b2fd9306549293c4ef
-  repo: https://github.com/docker/distribution
+  - aboutme
+  - utils
+  - k8s
 - name: github.com/docker/docker
   version: 2b27fe17a1b3fb8472fde96d768fa70996adf201
   subpackages:
@@ -209,79 +29,28 @@ imports:
   - pkg/term
   - pkg/timeutils
   - pkg/units
-- name: github.com/docker/go-units
-  version: 8e2d4523730c73120e10d4652f36ad6010998f4e
-- name: github.com/docker/goamz
-  version: 29510ec7eba995a3750f6b38128c5318f8b71592
-  subpackages:
-  - aws
-  - cloudfront
-  - s3
 - name: github.com/docker/libcontainer
   version: 5dc7ba0f24332273461e45bc49edcb4d5aa6c44c
-- name: github.com/docker/libkv
-  version: c2aac5dbbaa5c872211edea7c0f32b3bd67e7410
-- name: github.com/docker/libnetwork
-  version: 6cd5d90eb6b25d9e1ba41c45ad39f7df36d981b3
-  repo: https://github.com/docker/libnetwork
-- name: github.com/docker/libtrust
-  version: fa567046d9b14f6aa788882a950d69651d230b21
-  repo: https://github.com/docker/libtrust
-- name: github.com/docker/spdystream
-  version: b2c3287865f3ad6aa22821ddb7b4692b896ac207
-- name: github.com/elazarl/go-bindata-assetfs
-  version: 3dcc96556217539f50599357fb481ac0dc7439b9
+  subpackages:
+  - cgroups/fs
+  - configs
+  - cgroups
+  - system
 - name: github.com/emicklei/go-restful
   version: 1f9a0ee00ff93717a275e15b30cf7df356255877
-- name: github.com/evanphx/json-patch
-  version: 7dd4489c2eb6073e5a9d7746c3274c5b5f0387df
-- name: github.com/feyeleanor/raw
-  version: 724aedf6e1a5d8971aafec384b6bde3d5608fba4
-- name: github.com/feyeleanor/sets
-  version: 6c54cb57ea406ff6354256a4847e37298194478f
-- name: github.com/feyeleanor/slices
-  version: bb44bb2e4817fe71ba7082d351fd582e7d40e3ea
-- name: github.com/fsouza/go-dockerclient
-  version: 76fd6c68cf24c48ee6a2b25def997182a29f940e
-- name: github.com/garyburd/redigo
-  version: 535138d7bcd717d6531c701ef5933d98b1866257
   subpackages:
-  - internal
-  - redis
-- name: github.com/gedex/inflector
-  version: 8c0e57904488c554ab26caec525db5c92b23f051
-- name: github.com/getsentry/raven-go
-  version: 1cc47a9463b90f246a0503d4c2e9a55c9459ced3
-  repo: https://github.com/getsentry/raven-go
+  - swagger
+  - log
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/go-check/check
-  version: 4f90aeace3a26ad7021961c297b22c42160c7b25
-  repo: https://github.com/go-check/check
-- name: github.com/godbus/dbus
-  version: 939230d2086a4f1870e04c52e0a376c25bae0ec4
-- name: github.com/gogo/protobuf
-  version: 2093b57e5ca2ccbee4626814100bc1aada691b18
-  subpackages:
-  - proto
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
-- name: github.com/golang/groupcache
-  version: 604ed5785183e59ae2789449d89e73f3a2a77987
-  subpackages:
-  - lru
-- name: github.com/golang/mock
-  version: 15f8b22550555c0d3edf5afa97d74001bda2208b
-  subpackages:
-  - gomock
 - name: github.com/golang/protobuf
   version: 7f07925444bb51fa4cf9dfe6f7661876f8852275
   subpackages:
   - proto
-- name: github.com/google/btree
-  version: cc6329d4279e3f025a53a83c397d2339b5705c45
 - name: github.com/google/cadvisor
-  version: aa6f80814bc6fdb43a0ed12719658225420ffb7d
+  version: a8085bf9276c22f16dbcd7aa56f0d4d0626a0b2e
   subpackages:
   - api
   - cache/memory
@@ -303,180 +72,18 @@ imports:
   - version
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
-- name: github.com/GoogleCloudPlatform/gcloud-golang
-  version: 542bfb014d8e28df6e27be847dfdc40c510dab1a
-  subpackages:
-  - compute/metadata
-- name: github.com/gorilla/context
-  version: 215affda49addc4c8ef7e2534915df2c8c35c6cd
-- name: github.com/gorilla/handlers
-  version: 60c7bfde3e33c201519a200a4507a158cc03a17b
-- name: github.com/gorilla/mux
-  version: 8096f47503459bcc74d1f4c487b7e6e42e5746b5
-- name: github.com/gorilla/schema
-  version: 14c555599c2a4f493c1e13fd1ea6fdf721739028
-  repo: https://github.com/gorilla/schema
-- name: github.com/gorilla/websocket
-  version: 234959944d9cf05229b02e8b386e5cffe1e4e04a
-  repo: https://github.com/gorilla/websocket
-- name: github.com/Graylog2/go-gelf
-  version: 06974fc6689396066f6ebf5bab951d41979e3386
-  repo: https://github.com/Graylog2/go-gelf
-- name: github.com/hashicorp/consul
-  version: 954aec66231b79c161a4122b023fbcad13047f79
-  subpackages:
-  - api
-- name: github.com/hashicorp/go-checkpoint
-  version: e4b2dc34c0f698ee04750bf2035d8b9384233e1b
-  repo: https://github.com/hashicorp/go-checkpoint
-- name: github.com/hashicorp/go-cleanhttp
-  version: ce617e79981a8fff618bb643d155133a8f38db96
-  repo: https://github.com/hashicorp/go-cleanhttp
-- name: github.com/hashicorp/go-msgpack
-  version: 71c2886f5a673a35f909803f38ece5810165097b
-  subpackages:
-  - codec
-- name: github.com/hashicorp/go-syslog
-  version: 42a2b573b664dbf281bd48c3cc12c086b17a39ba
-  repo: https://github.com/hashicorp/go-syslog
-- name: github.com/hashicorp/go.net
-  version: 104dcad90073cd8d1e6828b2af19185b60cf3e29
-  repo: https://github.com/hashicorp/go.net
-- name: github.com/hashicorp/golang-lru
-  version: ce7dece472ba96dab1807940f0614f3254f883e7
-  repo: https://github.com/hashicorp/golang-lru
-- name: github.com/hashicorp/hcl
-  version: e96d23138c76470c808bf6586bdaf981bbd25cae
-  repo: https://github.com/hashicorp/hcl
-- name: github.com/hashicorp/logutils
-  version: 0dc08b1671f34c4250ce212759ebd880f743d883
-  repo: https://github.com/hashicorp/logutils
-- name: github.com/hashicorp/mdns
-  version: 9d85cf22f9f8d53cb5c81c1b2749f438b2ee333f
-  repo: https://github.com/hashicorp/mdns
-- name: github.com/hashicorp/memberlist
-  version: 9a1e242e454d2443df330bdd51a436d5a9058fc4
-- name: github.com/hashicorp/raft
-  version: 057b893fd996696719e98b6c44649ea14968c811
-  repo: https://github.com/hashicorp/raft
-- name: github.com/hashicorp/raft-mdb
-  version: 55f29473b9e604b3678b93a8433a6cf089e70f76
-  repo: https://github.com/hashicorp/raft-mdb
-- name: github.com/hashicorp/serf
-  version: 7151adcef72687bf95f451a2e0ba15cb19412bf2
-  subpackages:
-  - serf
-- name: github.com/hashicorp/yamux
-  version: df949784da9ed028ee76df44652e42d37a09d7e4
-  repo: https://github.com/hashicorp/yamux
-- name: github.com/hawkular/hawkular-client-go
-  version: 06bf87e3e131208c321ebd5d21576d94809537a1
-  subpackages:
-  - metrics
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
-- name: github.com/inconshreveable/mousetrap
-  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
-- name: github.com/inconshreveable/muxado
-  version: f693c7e88ba316d1a0ae3e205e22a01aa3ec2848
-  repo: https://github.com/inconshreveable/muxado
-- name: github.com/influxdb/go-cache
-  version: 7d1d6d6ae935664bc8b80ab2b1fc7ab77a7e46da
-  repo: https://github.com/influxdb/go-cache
-- name: github.com/influxdb/gomdb
-  version: 29fe330c5ab33c4e48470bd4b980bf522471190a
-  repo: https://github.com/influxdb/gomdb
-- name: github.com/influxdb/influxdb
-  version: afde71eb1740fd763ab9450e1f700ba0e53c36d0
-  subpackages:
-  - client
-- name: github.com/jmhodges/levigo
-  version: 1ddad808d437abb2b8a55a950ec2616caa88969b
-  repo: https://github.com/jmhodges/levigo
-- name: github.com/jonboulle/clockwork
-  version: 3f831b65b61282ba6bece21b91beea2edc4c887a
 - name: github.com/juju/ratelimit
   version: 772f5c38e468398c4511514f4f6aa9a4185bc0a0
-- name: github.com/julienschmidt/httprouter
-  version: 5273944025bdfe8df6c10f286ce7742b83673033
-  repo: https://github.com/julienschmidt/httprouter
-- name: github.com/kardianos/osext
-  version: 8fef92e41e22a70e700a96b29f066cda30ea24ef
-- name: github.com/kballard/go-shellquote
-  version: d8ec1a69a250a17bb0e419c386eac1f3711dc142
-- name: github.com/kimor79/gollectd
-  version: 61d0deeb4ffcc167b2a1baa8efd72365692811bc
-  repo: https://github.com/kimor79/gollectd
-- name: github.com/kr/pretty
-  version: 088c856450c08c03eb32f7a6c221e6eefaa10e6f
-- name: github.com/kr/pty
-  version: 05017fcccf23c823bfdea560dcc958a136e54fb7
-- name: github.com/kr/text
-  version: 6807e777504f54ad073ecef66747de158294b639
-- name: github.com/lsegal/gucumber
-  version: 44a4d7eb3b14a88cf82b073dfb7e06277afdc549
-  repo: https://github.com/lsegal/gucumber
-- name: github.com/Masterminds/cookoo
-  version: 78aa11ce75e257c51be7ea945edb84cf19c4a6de
-- name: github.com/mattn/go-isatty
-  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
-  repo: https://github.com/mattn/go-isatty
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
-- name: github.com/mesos/mesos-go
-  version: b164c06f346af1e93aecb6502f83d31dbacdbb91
-  subpackages:
-  - auth
-  - detector
-  - executor
-  - mesosproto
-  - mesosutil
-  - messenger
-  - scheduler
-  - upid
-- name: github.com/miekg/dns
-  version: 3f504e8dabd5d562e997d19ce0200aa41973e1b2
 - name: github.com/minio/minio-go
   version: c5884ce9ce3ac73b025d0bc58c4d3d72870edc0b
-- name: github.com/mistifyio/go-zfs
-  version: 1b4ae6fb4e77b095934d4430860ff202060169f8
-  repo: https://github.com/mistifyio/go-zfs
-- name: github.com/mitchellh/cli
-  version: 5c87c51cedf76a1737bf5ca3979e8644871598a6
-  repo: https://github.com/mitchellh/cli
-- name: github.com/mitchellh/mapstructure
-  version: 740c764bc6149d3f1806231418adb9f52c11bcbf
-- name: github.com/mjibson/appstats
-  version: 0542d5f0e87ea3a8fa4174322b9532f5d04f9fa8
-  repo: https://github.com/mjibson/appstats
-- name: github.com/mxk/go-flowrate
-  version: cca7078d478f8520f85629ad7c68962d31ed7682
-  subpackages:
-  - flowrate
-- name: github.com/ncw/swift
-  version: c54732e87b0b283d1baf0a18db689d0aea460ba3
-- name: github.com/noahdesu/go-ceph
-  version: b15639c44c05368348355229070361395d9152ee
-  subpackages:
-  - rados
-- name: github.com/olekukonko/ts
-  version: ecf753e7c962639ab5a1fb46f7da627d4c0a04b8
-- name: github.com/onsi/ginkgo
-  version: d981d36e9884231afa909627b9c275e4ba678f90
-- name: github.com/onsi/gomega
-  version: 8adf9e1730c55cdc590de7d49766cb2acc88d8f2
-- name: github.com/opencontainers/runc
-  version: ba1568de399395774ad84c2ace65937814c542ed
-  subpackages:
-  - libcontainer
-- name: github.com/opencontainers/specs
-  version: cf8dd120937acc3593708f99304c51cfd0f73240
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
-- name: github.com/progrium/go-extpoints
-  version: 529a176f52394e48e8882dd70a01732f1bb480f3
 - name: github.com/prometheus/client_golang
   version: 3b78d7a77f51ccbc364d4bc170920153022cfd08
   subpackages:
@@ -492,154 +99,16 @@ imports:
   - model
 - name: github.com/prometheus/procfs
   version: 490cc6eb5fa45bf8a8b7b73c8bc82a8160e8531d
-- name: github.com/rackspace/gophercloud
-  version: f92863476c034f851073599c09d90cd61ee95b3d
-- name: github.com/rakyll/globalconf
-  version: fd9ff89130a682478a0c94e893ff4affe570b002
-- name: github.com/rakyll/goini
-  version: 907cca0f578a5316fb864ec6992dc3d9730ec58c
-- name: github.com/rakyll/statik
-  version: 274df120e9065bdd08eb1120e0375e3dc1ae8465
-  repo: https://github.com/rakyll/statik
-- name: github.com/rcrowley/go-metrics
-  version: 51425a2415d21afadfd55cd93432c0bc69e9598d
-  repo: https://github.com/rcrowley/go-metrics
-- name: github.com/revel/revel
-  version: a9a2ff45fae4330ef4116b257bcf9c82e53350c2
-  repo: https://github.com/revel/revel
-- name: github.com/robfig/config
-  version: 0f78529c8c7e3e9a25f15876532ecbc07c7d99e6
-  repo: https://github.com/robfig/config
-- name: github.com/robfig/go-cache
-  version: 9fc39e0dbf62c034ec4e45e6120fc69433a3ec51
-  repo: https://github.com/robfig/go-cache
-- name: github.com/robfig/pathtree
-  version: 41257a1839e945fce74afd070e02bab2ea2c776a
-  repo: https://github.com/robfig/pathtree
-- name: github.com/russross/blackfriday
-  version: 77efab57b2f74dd3f9051c79752b2e8995c8b789
-- name: github.com/ryanuber/columnize
-  version: 983d3a5fab1bf04d1b412465d2d9f8430e2e917e
-  repo: https://github.com/ryanuber/columnize
-- name: github.com/samuel/go-zookeeper
-  version: 177002e16a0061912f02377e2dd8951a8b3551bc
-  subpackages:
-  - zk
-- name: github.com/scalingdata/gcfg
-  version: 37aabad69cfd3d20b8390d902a8b10e245c615ff
-- name: github.com/SeanDolphin/bqschema
-  version: f92a08f515e1bf718e995076a37c2f534b1deb08
-- name: github.com/seccomp/libseccomp-golang
-  version: 1b506fc7c24eec5a3693cdcbed40d9c226cfc6a1
-- name: github.com/shiena/ansicolor
-  version: a422bbe96644373c5753384a59d678f7d261ff10
-  repo: https://github.com/shiena/ansicolor
-- name: github.com/shurcooL/sanitized_anchor_name
-  version: 9a8b7d4e8f347bfa230879db9d7d4e4d9e19f962
-- name: github.com/Sirupsen/logrus
-  version: 51fe59aca108dc5680109e7b2051cbdcfa5a253c
-- name: github.com/skynetservices/skydns
-  version: 1be70b5b8aa07acccd972146d84011b670af88b4
-  subpackages:
-  - msg
-- name: github.com/spacejam/loghisto
-  version: 323309774dec8b7430187e46cd0793974ccca04a
-- name: github.com/spf13/cobra
-  version: 68f5a81a722d56241bd70faf6860ceb05eb27d64
 - name: github.com/spf13/pflag
   version: 8e7dc108ab3a1ab6ce6d922bbaff5657b88e8e49
-- name: github.com/stathat/go
-  version: cf69b0bcb80478755dc0ea1120b36000e35dcbbb
-  repo: https://github.com/stathat/go
-- name: github.com/stevvooe/resumable
-  version: 51ad44105773cafcbe91927f70ac68e1bf78f8b4
-- name: github.com/stretchr/objx
-  version: d40df0cc104c06eae2dfe03d7dddb83802d52f9a
-- name: github.com/stretchr/testify
-  version: 089c7181b8c728499929ff09b62d3fdd8df8adff
-  subpackages:
-  - assert
-  - mock
-  - require
-- name: github.com/syndtr/gocapability
-  version: 2c00daeb6c3b45114c80ac44119e7b8801fdd852
-  subpackages:
-  - capability
-- name: github.com/tchap/go-patricia
-  version: 42daf53d2c20234572a4640ac642df046505562d
-  repo: https://github.com/tchap/go-patricia
-- name: github.com/tobi/airbrake-go
-  version: a3cdd910a3ffef88a20fbecc10363a520ad61a0a
-  repo: https://github.com/tobi/airbrake-go
-- name: github.com/ugorji/go
-  version: 821cda7e48749cacf7cad2c6ed01e96457ca7e9d
-  subpackages:
-  - codec
-- name: github.com/vaughan0/go-ini
-  version: a98ad7ee00ec53921f08832bc06ecf7fd600e6a1
-- name: github.com/vishvananda/netlink
-  version: ae3e7dba57271b4e976c4f91637861ee477135e2
-- name: github.com/vishvananda/netns
-  version: 604eaf189ee867d8c147fafc28def2394e878d25
-  repo: https://github.com/vishvananda/netns
-- name: github.com/xiang90/probing
-  version: 6a0cc1ae81b4cc11db5e491e030e4b98fba79c19
-- name: github.com/xyproto/simpleredis
-  version: 5292687f5379e01054407da44d7c4590a61fd3de
-- name: github.com/yvasiyarov/go-metrics
-  version: 57bccd1ccd43f94bb17fdd8bf3007059b802f85e
-- name: github.com/yvasiyarov/gorelic
-  version: a9bba5b9ab508a086f9a12b8c51fab68478e2128
-- name: github.com/yvasiyarov/newrelic_platform_go
-  version: b21fdbd4370f3717f3bbd2bf41c223bc273068e6
 - name: golang.org/x/crypto
   version: c84e1f8e3a7e322d497cd16c0e8a13c7e127baf3
   subpackages:
   - ssh
-- name: golang.org/x/exp
-  version: d00e13ec443927751b2bd49e97dea7bf3b6a6487
-  subpackages:
-  - inotify
 - name: golang.org/x/net
   version: c2528b2dd8352441850638a8bb678c2ad056fd3e
   subpackages:
   - context
-- name: golang.org/x/oauth2
-  version: b5adcc2dcdf009d0391547edc6ecbaff889f5bb9
-- name: golang.org/x/sys
-  version: e11762ca30adc5b39fdbfd8c4250dabeb8e456d3
-  subpackages:
-  - unix
-- name: golang.org/x/text
-  version: db2353fc1b663d79d1001e206afc02a5ec9f4291
-  repo: https://golang.org/x/text
-- name: golang.org/x/tools
-  version: 4f50f44d7a3206e9e28b984e023efce2a4a75369
-  subpackages:
-  - go/ast/astutil
-  - imports
-- name: google.golang.org/api
-  version: 0c2979aeaa5b573e60d3ddffe5ce8dca8df309bd
-  subpackages:
-  - cloudmonitoring/v2beta2
-  - compute/v1
-  - container/v1beta1
-  - googleapi
-- name: google.golang.org/appengine
-  version: 6a436539be38c296a8075a871cc536686b458371
-  repo: https://google.golang.org/appengine
-- name: google.golang.org/cloud
-  version: 2e43671e4ad874a7bca65746ff3edb38e6e93762
-  subpackages:
-  - compute/metadata
-  - internal
-- name: google.golang.org/grpc
-  version: e29d659177655e589850ba7d3d83f7ce12ef23dd
-- name: gopkg.in/check.v1
-  version: 64131543e7896d5bcc6bd5a76287eb75ea96c673
-- name: gopkg.in/fsnotify.v1
-  version: 8611c35ab31c1c28aa903d33cf8b6e44a399b09e
-  repo: https://gopkg.in/fsnotify.v1
 - name: gopkg.in/natefinch/lumberjack.v2
   version: 600ceb4523e5b7ff745f91083c8a023c2bf73af5
 - name: gopkg.in/olivere/elastic.v2
@@ -647,23 +116,53 @@ imports:
 - name: gopkg.in/tomb.v1
   version: dd632973f1e7218eb1089048e0798ec9ae7dceb8
 - name: gopkg.in/v2/yaml
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
-- name: gopkg.in/yaml.v1
-  version: 9f9df34309c04878acc86042b16630b0f696e1de
-  repo: https://gopkg.in/yaml.v1
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
-- name: k8s.io/heapster
-  version: 0e1b652781812dee2c51c75180fc590223e0b9c6
-  subpackages:
-  - api/v1/types
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: k8s.io/kubernetes
-  version: 92635e23dfafb2ddc828c8ac6c03c7a7205a84d8
+  version: 596055084fbaef446983b14097f832f60ae57634
   subpackages:
-  - pkg
-- name: launchpad.net/gocheck
-  version: ""
-  repo: https://launchpad.net/gocheck
+  - pkg/api
+  - pkg/client/unversioned
+  - pkg/labels
+  - pkg/client/unversioned/clientcmd
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/api/unversioned
+  - pkg/auth/user
+  - pkg/conversion
+  - pkg/fields
+  - pkg/runtime
+  - pkg/types
+  - pkg/util
+  - pkg/util/rand
+  - pkg/util/sets
+  - pkg/api/errors
+  - pkg/api/install
+  - pkg/api/latest
+  - pkg/api/validation
+  - pkg/apis/extensions
+  - pkg/apis/extensions/install
+  - pkg/client/metrics
+  - pkg/conversion/queryparams
+  - pkg/util/wait
+  - pkg/version
+  - pkg/watch
+  - pkg/watch/json
+  - pkg/util/fielderrors
+  - pkg/util/validation
+  - pkg/client/unversioned/auth
+  - pkg/client/unversioned/clientcmd/api
+  - pkg/client/unversioned/clientcmd/api/latest
+  - pkg/util/errors
+  - third_party/forked/reflect
+  - pkg/util/yaml
+  - pkg/api/registered
+  - pkg/api/util
+  - pkg/api/v1
+  - pkg/capabilities
+  - pkg/apis/extensions/v1beta1
+  - pkg/client/unversioned/clientcmd/api/v1
 - name: speter.net/go/exp/math/dec/inf
   version: 42ca6cd68aa922bc3f32f1e056e61b65945d9ad7
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,11 +12,11 @@ import:
 - package: gopkg.in/tomb.v1
   version: dd632973f1e7218eb1089048e0798ec9ae7dceb8
 - package: gopkg.in/v2/yaml
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - package: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 - package: github.com/deis/pkg
-  version: f63d9718b86f17c9320f838fb3eb6039cadb9691
+  version: v0.4.0
   subpackages:
   - /aboutme
   - /utils


### PR DESCRIPTION
Also updated deis/pkg and yaml.v2 dependencies with newer `glide`.
