### PR TITLE
fix(*): resolve build and container start issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build:
 test:
 	${DEV_ENV_CMD} go test ${TEST_PACKAGES}
 
-docker-build: build-server
+docker-build: build build-server
 	# copy the server binary from where it was built to the final image's file system.
 	# note that the minio server is built as a dependency of this build target.
 	cp server/minio ${BINDIR}

--- a/boot.go
+++ b/boot.go
@@ -40,7 +40,7 @@ const configdir = "/home/minio/.minio/"
 const templv3 = `{
 	"version": "3",
 	"alias": {
-		"dl": "https://dl.minio.io:9000",
+		"dl": "https://dl.minio.io",
 		"localhost": "http://localhost:9000",
 		"play": "https://play.minio.io:9000",
 		"s3": "https://s3.amazonaws.com"

--- a/glide.lock
+++ b/glide.lock
@@ -14,7 +14,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/deis/pkg
-  version: 20cd6d3875d29b186b47d7466dcc1672db01619c
+  version: f63d9718b86f17c9320f838fb3eb6039cadb9691
   subpackages:
   - aboutme
   - utils

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,7 +16,7 @@ import:
 - package: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 - package: github.com/deis/pkg
-  version: v0.4.0
+  version: f63d9718b86f17c9320f838fb3eb6039cadb9691
   subpackages:
   - /aboutme
   - /utils

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,9 +5,9 @@ ENV MINIOUSER minio
 ENV DEIS_RELEASE=2.0.0-dev
 RUN useradd -m -d $MINIOHOME $MINIOUSER
 RUN apt-get update -y && apt-get install -y -q ca-certificates curl
-RUN curl -f -SL https://dl.minio.io:9000/updates/2015/Sept/linux-amd64/mc -o /usr/bin/mc
+RUN curl -f -SL https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.OFFICIAL.2015-09-05T23-43-46Z -o /usr/bin/mc
 RUN chmod 755 /usr/bin/mc
 COPY . /
 USER minio
 RUN mkdir /home/minio/.minio
-CMD "boot"
+CMD ["/bin/boot"]

--- a/server/install.sh
+++ b/server/install.sh
@@ -15,5 +15,7 @@ cd $GOPATH/src/github.com/minio
 git clone -b master --single-branch https://github.com/minio/minio.git minio
 cd minio
 git reset --hard 356b889
+# HACK remove the "go vet" installation line
+sed -i.bak '63 d' Makefile
 make install
 cp $GOPATH/bin/minio /pwd/minio


### PR DESCRIPTION
The old URL for fetching `mc` was replaced by a new server and paths, which broke the [deis/minio build](https://travis-ci.org/deis/minio/builds/120983406). Additionally, `go vet` is no longer installed that way, so this removes that line from install.sh before building. This also reverts a change back to the last-known-good version of deis/pkg/aboutme.
