### PR TITLE
chore(rootfs,mc/Dockerfile): DEIS_RELEASE -> WORKFLOW_RELEASE

### DIFF
--- a/mc/Dockerfile
+++ b/mc/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add -U ca-certificates && rm -rf /var/cache/apk/*
 
 ADD mc /bin/mc
 
-ENV DEIS_RELEASE=2.0.0-dev
+ENV WORKFLOW_RELEASE=2.0.0-dev
 ADD ./integration/integration.sh /bin/integration.sh
 RUN chmod +x /bin/integration.sh
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 ENV MINIOHOME /home/minio
 ENV MINIOUSER minio
-ENV DEIS_RELEASE=2.0.0-dev
+ENV WORKFLOW_RELEASE=2.0.0-dev
 RUN useradd -m -d $MINIOHOME $MINIOUSER
 RUN apt-get update -y && apt-get install -y -q ca-certificates curl
 RUN curl -f -SL https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.OFFICIAL.2015-09-05T23-43-46Z -o /usr/bin/mc


### PR DESCRIPTION
Update `DEIS_RELEASE` to be `WORKFLOW_RELEASE` as done similarly elsewhere (see https://github.com/deis/workflow/pull/193)
