### PR TITLE
fix(Dockerfile): download minio from a mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ docker-build: build
 
 deploy: build docker-build docker-push
 
-.PHONY: all bootstrap glideup build test docker-build deploy build-server
+.PHONY: all bootstrap glideup build test docker-build deploy

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ The Deis project welcomes contributions from all developers. The high level proc
 * If your PR fixes any [issues][issues], make sure you write Fixes #1234 in your PR description (where #1234 is the number of the issue you're closing)
 * The Deis core contributors will review your code. After each of them sign off on your code, they'll label your PR with `LGTM1` and `LGTM2` (respectively). Once that happens, you may merge.
 
+## Minio Binary Mirror
+
+Also, note that the [Dockerfile](rootfs/Dockerfile) uses an `ADD` directive to download pre-built Minio binaries from a [Google Cloud Storage bucket](https://console.cloud.google.com/storage/browser/minio-mirror/?project=deis-mirrors). The bucket is in the `deis-mirrors` project, and if you have access to that project, [this link](https://console.cloud.google.com/storage/browser/minio-mirror/?project=deis-mirrors) should take you directly to that bucket.
+
+To bump this component to use a newer build of Minio, simply add a new binary to the bucket (under the `linux-amd64` folder), check the checkbox under the `Share publicly` column, and update the URL in the `ADD` directive in the aforementioned `Dockerfile`.
+
 ## Docker Based Development Environment
 
 The preferred environment for development uses the [`go-dev` Docker image](https://github.com/deis/docker-go-dev). The tools described in this section are used to build, test, package and release each version of Deis.

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -f -SL https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.OFF
 	&& chmod 755 /usr/bin/mc \
 	&& mkdir /home/minio/.minio \
 	&& chown minio:minio /home/minio/.minio
-ADD https://dl.minio.io/server/minio/release/linux-amd64/minio.RELEASE.2016-06-03T19-32-05Z /bin/minio
+ADD https://storage.googleapis.com/minio-mirror/linux-amd64/minio-2016-06-03T19-32-05Z /bin/minio
 RUN chmod 755 /bin/minio
 
 USER minio


### PR DESCRIPTION
The mirror is in GCS

Fixes https://github.com/deis/minio/issues/108
