### PR TITLE
ref(Makefile): remove obsolete "docker tag -f" flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docker-build: build
 
 	# build the main image
 	docker build --rm -t ${IMAGE} rootfs
-	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
+	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 
 deploy: build docker-build docker-push


### PR DESCRIPTION
This is an error with Docker 1.12.
