### PR TITLE
chore(Makefile): update to go-dev 0.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ sudo: required
 install:
   - make bootstrap
 script:
-  - make test build docker-build
+  - DEIS_REGISTRY='' make test build docker-build

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,9 @@ test:
 	${DEV_ENV_CMD} go test ${TEST_PACKAGES}
 
 docker-build: build
-
 	# build the main image
 	docker build --rm -t ${IMAGE} rootfs
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
-
 
 deploy: build docker-build docker-push
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 SHORT_NAME := minio
 
-export GO15VENDOREXPERIMENT=1
-
 # dockerized development environment variables
 REPO_PATH := github.com/deis/${SHORT_NAME}
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.1
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_PREFIX := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:0.2.0
+FROM quay.io/deis/base:0.3.1
 
 RUN adduser --system \
 	--shell /bin/bash \


### PR DESCRIPTION
Includes the go 1.7 toolchain: faster, smaller, better. See https://tip.golang.org/doc/go1.7.

Also updates the Docker base image to deis/base:0.3.1.
