### PR TITLE
fix(codecov): add test-cover target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 rootfs/bin/minio
 rootfs/bin/boot
 vendor/
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ sudo: required
 install:
   - make bootstrap
 script:
-  - DEIS_REGISTRY='' make test build docker-build
+  - DEIS_REGISTRY='' make test-cover build docker-build
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ build:
 test:
 	${DEV_ENV_CMD} go test ${TEST_PACKAGES}
 
+test-cover:
+	${DEV_ENV_CMD} test-cover.sh
+
 docker-build: build
 	# build the main image
 	docker build --rm -t ${IMAGE} rootfs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  branch: master
+  slug: "deis/minio"


### PR DESCRIPTION
Travis wasn't generating a coverage report for codecov so nothing was being displayed at
https://codecov.io/gh/deis/minio/